### PR TITLE
Review

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/admin/concurrency/ConcurrencyTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/concurrency/ConcurrencyTest.java
@@ -18,7 +18,9 @@
 package org.keycloak.tests.admin.concurrency;
 
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.ClientsResource;
@@ -55,6 +57,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
 @KeycloakIntegrationTest
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class ConcurrencyTest extends AbstractConcurrencyTest {
 
     // Verify that no attribute values are duplicated, and there are no locking exceptions when adding attributes in parallel
@@ -71,9 +74,10 @@ public class ConcurrencyTest extends AbstractConcurrencyTest {
 
         UserRepresentation u = UserConfigBuilder.create().username("attributes").build();
 
-        Response response = users.create(u);
-        String userId = ApiUtil.getCreatedId(response);
-        response.close();
+        String userId;
+        try (Response response = users.create(u)) {
+            userId = ApiUtil.getCreatedId(response);
+        }
 
         UserResource user = users.get(userId);
 
@@ -128,9 +132,10 @@ public class ConcurrencyTest extends AbstractConcurrencyTest {
     public void createClientRole() throws Throwable {
         ClientRepresentation c = new ClientRepresentation();
         c.setClientId("client");
-        Response response = managedRealm.admin().clients().create(c);
-        final String clientId = ApiUtil.getCreatedId(response);
-        response.close();
+        final String clientId;
+        try (Response response = managedRealm.admin().clients().create(c)) {
+            clientId = ApiUtil.getCreatedId(response);
+        }
 
         AtomicInteger uniqueCounter = new AtomicInteger();
         concurrentTest(new CreateClientRole(uniqueCounter, clientId));
@@ -163,9 +168,10 @@ public class ConcurrencyTest extends AbstractConcurrencyTest {
             String name = "c-" + clientIndex.getAndIncrement();
             ClientRepresentation c = new ClientRepresentation();
             c.setClientId(name);
-            Response response = realm.clients().create(c);
-            String id = ApiUtil.getCreatedId(response);
-            response.close();
+            String id;
+            try (Response response = realm.clients().create(c)) {
+                id = ApiUtil.getCreatedId(response);
+            }
 
             c = realm.clients().get(id).toRepresentation();
             assertNotNull(c);
@@ -197,9 +203,10 @@ public class ConcurrencyTest extends AbstractConcurrencyTest {
             c.setClientId(name);
             final ClientsResource clients = realm.clients();
 
-            Response response = clients.create(c);
-            String id = ApiUtil.getCreatedId(response);
-            response.close();
+            String id;
+            try (Response response = clients.create(c)) {
+                id = ApiUtil.getCreatedId(response);
+            }
             final ClientResource client = clients.get(id);
 
             c = client.toRepresentation();
@@ -243,9 +250,10 @@ public class ConcurrencyTest extends AbstractConcurrencyTest {
             String name = "g-" + uniqueIndex.getAndIncrement();
             GroupRepresentation c = new GroupRepresentation();
             c.setName(name);
-            Response response = realm.groups().add(c);
-            String id = ApiUtil.getCreatedId(response);
-            response.close();
+            String id;
+            try (Response response = realm.groups().add(c)) {
+                id = ApiUtil.getCreatedId(response);
+            }
 
             c = realm.groups().group(id).toRepresentation();
             assertNotNull(c);


### PR DESCRIPTION
I found that Keycloak was idle, and the tests were waiting for connections to be come available. 

There were some exceptions with mariadb that were recorded but not yet logged. And the closing of the response was missing in case of exceptions. With this change, it now logs this exceptions on the console.


```
2025-04-15 11:15:25,069 ERROR [org.keycloak.tests.admin.concurrency.AbstractConcurrencyTest] (main) expected: <201> but was: <409>: org.opentest4j.AssertionFailedError: expected: <201> but was: <409>
        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:150)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:145)
        at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:531)
        at org.keycloak.tests.utils.admin.ApiUtil.getCreatedId(ApiUtil.java:54)
        at org.keycloak.tests.admin.concurrency.ConcurrencyTest$CreateRemoveClient.run(ConcurrencyTest.java:208)
        at org.keycloak.tests.admin.concurrency.AbstractConcurrencyTest.lambda$run$0(AbstractConcurrencyTest.java:103)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
